### PR TITLE
Arduino:C33:sci6 - fix default pins

### DIFF
--- a/boards/arduino/portenta_c33/arduino_portenta_c33-pinctrl.dtsi
+++ b/boards/arduino/portenta_c33/arduino_portenta_c33-pinctrl.dtsi
@@ -37,10 +37,10 @@
 	sci6_default: sci6_default {
 		group1 {
 			/* tx rx */
-			psels = <RA_PSEL(RA_PSEL_SCI_5, 8, 5)>,
-				<RA_PSEL(RA_PSEL_SCI_5, 5, 13)>,
-				<RA_PSEL(RA_PSEL_SCI_5, 5, 8)>,
-				<RA_PSEL(RA_PSEL_SCI_5, 5, 0)>;
+			psels = <RA_PSEL(RA_PSEL_SCI_6, 5, 6)>,
+				<RA_PSEL(RA_PSEL_SCI_6, 3, 4)>,
+				<RA_PSEL(RA_PSEL_SCI_6, 5, 3)>,
+				<RA_PSEL(RA_PSEL_SCI_6, 5, 2)>;
 		};
 	};
 


### PR DESCRIPTION
The default pins looks like it copied the sci5 data and then did not update it to the right object and port/pins

@facchinm, @pillo79 - I think this is your latest branch so that I would apply my fix for SCI6
As I am working on getting some of the Serial objects to work